### PR TITLE
Implement Query/Scan dispatch and memory-engine support

### DIFF
--- a/integration/phase0_phase1_test.go
+++ b/integration/phase0_phase1_test.go
@@ -138,3 +138,113 @@ func TestTableLifecycleAndCoreCRUD(t *testing.T) {
 		t.Fatalf("expected resource not found, got: %v", err)
 	}
 }
+
+func TestQueryAndScanRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	h := testutil.NewHarness(t)
+	client := h.Client
+
+	_, err := client.CreateTable(ctx, &dynamodb.CreateTableInput{
+		TableName: aws.String("phase1_qs"),
+		AttributeDefinitions: []types.AttributeDefinition{
+			{AttributeName: aws.String("pk"), AttributeType: types.ScalarAttributeTypeS},
+			{AttributeName: aws.String("sk"), AttributeType: types.ScalarAttributeTypeN},
+		},
+		KeySchema: []types.KeySchemaElement{
+			{AttributeName: aws.String("pk"), KeyType: types.KeyTypeHash},
+			{AttributeName: aws.String("sk"), KeyType: types.KeyTypeRange},
+		},
+		BillingMode: types.BillingModePayPerRequest,
+	})
+	if err != nil {
+		t.Fatalf("create table failed: %v", err)
+	}
+
+	items := []map[string]types.AttributeValue{
+		{"pk": &types.AttributeValueMemberS{Value: "tenant#1"}, "sk": &types.AttributeValueMemberN{Value: "1"}, "name": &types.AttributeValueMemberS{Value: "a"}},
+		{"pk": &types.AttributeValueMemberS{Value: "tenant#1"}, "sk": &types.AttributeValueMemberN{Value: "2"}, "name": &types.AttributeValueMemberS{Value: "b"}},
+		{"pk": &types.AttributeValueMemberS{Value: "tenant#1"}, "sk": &types.AttributeValueMemberN{Value: "3"}, "name": &types.AttributeValueMemberS{Value: "c"}},
+		{"pk": &types.AttributeValueMemberS{Value: "tenant#2"}, "sk": &types.AttributeValueMemberN{Value: "1"}, "name": &types.AttributeValueMemberS{Value: "d"}},
+	}
+	for _, item := range items {
+		_, err = client.PutItem(ctx, &dynamodb.PutItemInput{TableName: aws.String("phase1_qs"), Item: item})
+		if err != nil {
+			t.Fatalf("put failed: %v", err)
+		}
+	}
+
+	queryOut, err := client.Query(ctx, &dynamodb.QueryInput{
+		TableName:              aws.String("phase1_qs"),
+		KeyConditionExpression: aws.String("#pk = :pk AND #sk >= :min"),
+		ExpressionAttributeNames: map[string]string{
+			"#pk": "pk",
+			"#sk": "sk",
+		},
+		ExpressionAttributeValues: map[string]types.AttributeValue{
+			":pk":  &types.AttributeValueMemberS{Value: "tenant#1"},
+			":min": &types.AttributeValueMemberN{Value: "2"},
+		},
+		ScanIndexForward: aws.Bool(false),
+	})
+	if err != nil {
+		t.Fatalf("query failed: %v", err)
+	}
+	if got, want := len(queryOut.Items), 2; got != want {
+		t.Fatalf("query items got=%d want=%d", got, want)
+	}
+	if got := queryOut.Items[0]["sk"].(*types.AttributeValueMemberN).Value; got != "3" {
+		t.Fatalf("expected descending sort, first sk=%s", got)
+	}
+
+	paged, err := client.Query(ctx, &dynamodb.QueryInput{
+		TableName:              aws.String("phase1_qs"),
+		KeyConditionExpression: aws.String("pk = :pk"),
+		ExpressionAttributeValues: map[string]types.AttributeValue{
+			":pk": &types.AttributeValueMemberS{Value: "tenant#1"},
+		},
+		Limit: aws.Int32(2),
+	})
+	if err != nil {
+		t.Fatalf("paged query failed: %v", err)
+	}
+	if got, want := len(paged.Items), 2; got != want {
+		t.Fatalf("paged query items got=%d want=%d", got, want)
+	}
+	if len(paged.LastEvaluatedKey) == 0 {
+		t.Fatalf("expected LastEvaluatedKey for paged query")
+	}
+
+	next, err := client.Query(ctx, &dynamodb.QueryInput{
+		TableName:              aws.String("phase1_qs"),
+		KeyConditionExpression: aws.String("pk = :pk"),
+		ExpressionAttributeValues: map[string]types.AttributeValue{
+			":pk": &types.AttributeValueMemberS{Value: "tenant#1"},
+		},
+		ExclusiveStartKey: paged.LastEvaluatedKey,
+	})
+	if err != nil {
+		t.Fatalf("next page query failed: %v", err)
+	}
+	if got, want := len(next.Items), 1; got != want {
+		t.Fatalf("next page items got=%d want=%d", got, want)
+	}
+
+	scanOut, err := client.Scan(ctx, &dynamodb.ScanInput{TableName: aws.String("phase1_qs")})
+	if err != nil {
+		t.Fatalf("scan failed: %v", err)
+	}
+	if got, want := len(scanOut.Items), 4; got != want {
+		t.Fatalf("scan items got=%d want=%d", got, want)
+	}
+
+	scanCount, err := client.Scan(ctx, &dynamodb.ScanInput{TableName: aws.String("phase1_qs"), Select: types.SelectCount})
+	if err != nil {
+		t.Fatalf("scan count failed: %v", err)
+	}
+	if got, want := scanCount.Count, int32(4); got != want {
+		t.Fatalf("scan count got=%d want=%d", got, want)
+	}
+	if len(scanCount.Items) != 0 {
+		t.Fatalf("expected no items for Select=COUNT")
+	}
+}

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -57,6 +57,10 @@ func (s *Server) handle(w http.ResponseWriter, r *http.Request) {
 		s.deleteItem(w, payload)
 	case "UpdateItem":
 		s.updateItem(w, payload)
+	case "Query":
+		s.query(w, payload)
+	case "Scan":
+		s.scan(w, payload)
 	default:
 		writeError(w, http.StatusBadRequest, "ValidationException", fmt.Sprintf("Unknown operation %s", parts[1]))
 	}
@@ -301,6 +305,79 @@ func (s *Server) updateItem(w http.ResponseWriter, payload []byte) {
 	_, _ = w.Write([]byte("{}"))
 }
 
+func (s *Server) query(w http.ResponseWriter, payload []byte) {
+	var in struct {
+		TableName                 string            `json:"TableName"`
+		KeyConditionExpression    string            `json:"KeyConditionExpression"`
+		ExpressionAttributeNames  map[string]string `json:"ExpressionAttributeNames"`
+		ExpressionAttributeValues json.RawMessage   `json:"ExpressionAttributeValues"`
+		ExclusiveStartKey         json.RawMessage   `json:"ExclusiveStartKey"`
+		Limit                     int32             `json:"Limit"`
+		ScanIndexForward          *bool             `json:"ScanIndexForward"`
+		Select                    types.Select      `json:"Select"`
+	}
+	if err := json.Unmarshal(payload, &in); err != nil {
+		writeError(w, 400, "ValidationException", err.Error())
+		return
+	}
+	values, err := unmarshalOptionalMap(in.ExpressionAttributeValues)
+	if err != nil {
+		writeError(w, 400, "ValidationException", err.Error())
+		return
+	}
+	startKey, err := unmarshalOptionalMap(in.ExclusiveStartKey)
+	if err != nil {
+		writeError(w, 400, "ValidationException", err.Error())
+		return
+	}
+	scanForward := true
+	if in.ScanIndexForward != nil {
+		scanForward = *in.ScanIndexForward
+	}
+	out, err := s.engine.Query(in.TableName, storage.QueryInput{
+		KeyConditionExpression:    in.KeyConditionExpression,
+		ExpressionAttributeNames:  in.ExpressionAttributeNames,
+		ExpressionAttributeValues: values,
+		ExclusiveStartKey:         startKey,
+		Limit:                     in.Limit,
+		ScanIndexForward:          scanForward,
+		Select:                    in.Select,
+	})
+	if err != nil {
+		writeTyped(w, err)
+		return
+	}
+	writeCollectionEnvelope(w, out.Items, out.Count, out.ScannedCount, out.LastEvaluatedKey)
+}
+
+func (s *Server) scan(w http.ResponseWriter, payload []byte) {
+	var in struct {
+		TableName         string          `json:"TableName"`
+		ExclusiveStartKey json.RawMessage `json:"ExclusiveStartKey"`
+		Limit             int32           `json:"Limit"`
+		Select            types.Select    `json:"Select"`
+	}
+	if err := json.Unmarshal(payload, &in); err != nil {
+		writeError(w, 400, "ValidationException", err.Error())
+		return
+	}
+	startKey, err := unmarshalOptionalMap(in.ExclusiveStartKey)
+	if err != nil {
+		writeError(w, 400, "ValidationException", err.Error())
+		return
+	}
+	out, err := s.engine.Scan(in.TableName, storage.ScanInput{
+		ExclusiveStartKey: startKey,
+		Limit:             in.Limit,
+		Select:            in.Select,
+	})
+	if err != nil {
+		writeTyped(w, err)
+		return
+	}
+	writeCollectionEnvelope(w, out.Items, out.Count, out.ScannedCount, out.LastEvaluatedKey)
+}
+
 func writeItemEnvelope(w http.ResponseWriter, key string, item map[string]types.AttributeValue) {
 	b, err := attributevalue.MarshalMapJSON(item)
 	if err != nil {
@@ -316,6 +393,41 @@ func cloneMap(in map[string]types.AttributeValue) map[string]types.AttributeValu
 		out[k] = v
 	}
 	return out
+}
+
+func unmarshalOptionalMap(raw json.RawMessage) (map[string]types.AttributeValue, error) {
+	if len(raw) == 0 || string(raw) == "null" {
+		return nil, nil
+	}
+	return attributevalue.UnmarshalMapJSON(raw)
+}
+
+func writeCollectionEnvelope(w http.ResponseWriter, items []map[string]types.AttributeValue, count, scannedCount int32, last map[string]types.AttributeValue) {
+	resp := map[string]any{"Count": count, "ScannedCount": scannedCount}
+	if len(items) > 0 {
+		respItems := make([]json.RawMessage, 0, len(items))
+		for _, item := range items {
+			b, err := attributevalue.MarshalMapJSON(item)
+			if err != nil {
+				writeError(w, 500, "InternalServerError", err.Error())
+				return
+			}
+			respItems = append(respItems, b)
+		}
+		resp["Items"] = respItems
+	}
+	if len(last) > 0 {
+		b, err := attributevalue.MarshalMapJSON(last)
+		if err != nil {
+			writeError(w, 500, "InternalServerError", err.Error())
+			return
+		}
+		resp["LastEvaluatedKey"] = json.RawMessage(b)
+	}
+	if _, ok := resp["Items"]; !ok {
+		resp["Items"] = []json.RawMessage{}
+	}
+	_ = json.NewEncoder(w).Encode(resp)
 }
 
 func writeTyped(w http.ResponseWriter, err error) {

--- a/pkg/storage/engine.go
+++ b/pkg/storage/engine.go
@@ -1,7 +1,11 @@
 package storage
 
 import (
+	"bytes"
 	"fmt"
+	"math/big"
+	"sort"
+	"strings"
 	"sync"
 
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
@@ -23,6 +27,38 @@ type Engine interface {
 	PutItem(table string, item map[string]types.AttributeValue) (map[string]types.AttributeValue, error)
 	GetItem(table string, key map[string]types.AttributeValue) (map[string]types.AttributeValue, error)
 	DeleteItem(table string, key map[string]types.AttributeValue) (map[string]types.AttributeValue, error)
+	Query(table string, in QueryInput) (QueryOutput, error)
+	Scan(table string, in ScanInput) (ScanOutput, error)
+}
+
+type QueryInput struct {
+	KeyConditionExpression    string
+	ExpressionAttributeNames  map[string]string
+	ExpressionAttributeValues map[string]types.AttributeValue
+	ExclusiveStartKey         map[string]types.AttributeValue
+	Limit                     int32
+	ScanIndexForward          bool
+	Select                    types.Select
+}
+
+type QueryOutput struct {
+	Items            []map[string]types.AttributeValue
+	Count            int32
+	ScannedCount     int32
+	LastEvaluatedKey map[string]types.AttributeValue
+}
+
+type ScanInput struct {
+	ExclusiveStartKey map[string]types.AttributeValue
+	Limit             int32
+	Select            types.Select
+}
+
+type ScanOutput struct {
+	Items            []map[string]types.AttributeValue
+	Count            int32
+	ScannedCount     int32
+	LastEvaluatedKey map[string]types.AttributeValue
 }
 
 type MemoryEngine struct {
@@ -107,6 +143,132 @@ func (m *MemoryEngine) DeleteItem(table string, key map[string]types.AttributeVa
 	return old, nil
 }
 
+func (m *MemoryEngine) Query(table string, in QueryInput) (QueryOutput, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	t, schema, err := m.getTableLocked(table)
+	if err != nil {
+		return QueryOutput{}, err
+	}
+	cond, err := parseKeyCondition(in.KeyConditionExpression, schema, in.ExpressionAttributeNames, in.ExpressionAttributeValues)
+	if err != nil {
+		return QueryOutput{}, err
+	}
+
+	type row struct {
+		key  Key
+		item map[string]types.AttributeValue
+	}
+	rows := make([]row, 0, len(t.items))
+	for k, item := range t.items {
+		if !attributeEqual(item[schema.PartitionKey], cond.pkValue) {
+			continue
+		}
+		if schema.SortKey != "" {
+			if ok, err := cond.matchesSort(item[schema.SortKey]); err != nil || !ok {
+				if err != nil {
+					return QueryOutput{}, err
+				}
+				continue
+			}
+		}
+		rows = append(rows, row{key: k, item: cloneItem(item)})
+	}
+	sort.Slice(rows, func(i, j int) bool {
+		cmp := strings.Compare(rows[i].key.SK, rows[j].key.SK)
+		if cmp == 0 {
+			cmp = strings.Compare(rows[i].key.PK, rows[j].key.PK)
+		}
+		if !in.ScanIndexForward {
+			return cmp > 0
+		}
+		return cmp < 0
+	})
+
+	start := 0
+	if len(in.ExclusiveStartKey) > 0 {
+		exclusive, err := makeKey(in.ExclusiveStartKey, schema)
+		if err != nil {
+			return QueryOutput{}, err
+		}
+		for i, r := range rows {
+			if r.key == exclusive {
+				start = i + 1
+				break
+			}
+		}
+	}
+
+	limited := rows[start:]
+	var last map[string]types.AttributeValue
+	if in.Limit > 0 && int(in.Limit) < len(limited) {
+		limited = limited[:in.Limit]
+		last = keyFromItem(limited[len(limited)-1].item, schema)
+	}
+
+	out := QueryOutput{Count: int32(len(limited)), ScannedCount: int32(len(rows)), LastEvaluatedKey: last}
+	if in.Select != types.SelectCount {
+		out.Items = make([]map[string]types.AttributeValue, 0, len(limited))
+		for _, r := range limited {
+			out.Items = append(out.Items, r.item)
+		}
+	}
+	return out, nil
+}
+
+func (m *MemoryEngine) Scan(table string, in ScanInput) (ScanOutput, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	t, schema, err := m.getTableLocked(table)
+	if err != nil {
+		return ScanOutput{}, err
+	}
+	type row struct {
+		key  Key
+		item map[string]types.AttributeValue
+	}
+	rows := make([]row, 0, len(t.items))
+	for k, item := range t.items {
+		rows = append(rows, row{key: k, item: cloneItem(item)})
+	}
+	sort.Slice(rows, func(i, j int) bool {
+		if rows[i].key.PK == rows[j].key.PK {
+			return rows[i].key.SK < rows[j].key.SK
+		}
+		return rows[i].key.PK < rows[j].key.PK
+	})
+
+	start := 0
+	if len(in.ExclusiveStartKey) > 0 {
+		exclusive, err := makeKey(in.ExclusiveStartKey, schema)
+		if err != nil {
+			return ScanOutput{}, err
+		}
+		for i, r := range rows {
+			if r.key == exclusive {
+				start = i + 1
+				break
+			}
+		}
+	}
+
+	limited := rows[start:]
+	var last map[string]types.AttributeValue
+	if in.Limit > 0 && int(in.Limit) < len(limited) {
+		limited = limited[:in.Limit]
+		last = keyFromItem(limited[len(limited)-1].item, schema)
+	}
+
+	out := ScanOutput{Count: int32(len(limited)), ScannedCount: int32(len(rows)), LastEvaluatedKey: last}
+	if in.Select != types.SelectCount {
+		out.Items = make([]map[string]types.AttributeValue, 0, len(limited))
+		for _, r := range limited {
+			out.Items = append(out.Items, r.item)
+		}
+	}
+	return out, nil
+}
+
 func (m *MemoryEngine) getTableLocked(name string) (*memTable, TableSchema, error) {
 	t, ok := m.tables[name]
 	if !ok {
@@ -159,6 +321,163 @@ func cloneItem(in map[string]types.AttributeValue) map[string]types.AttributeVal
 	out := make(map[string]types.AttributeValue, len(in))
 	for k, v := range in {
 		out[k] = v
+	}
+	return out
+}
+
+type keyCondition struct {
+	pkValue types.AttributeValue
+	skOp    string
+	skOne   types.AttributeValue
+	skTwo   types.AttributeValue
+}
+
+func parseKeyCondition(expr string, schema TableSchema, names map[string]string, values map[string]types.AttributeValue) (keyCondition, error) {
+	if expr == "" {
+		return keyCondition{}, fmt.Errorf("ValidationException: KeyConditionExpression is required")
+	}
+	resolved := expr
+	for k, v := range names {
+		resolved = strings.ReplaceAll(resolved, k, v)
+	}
+	parts := strings.SplitN(resolved, "AND", 2)
+	pkPart := strings.TrimSpace(parts[0])
+	toks := strings.Fields(pkPart)
+	if len(toks) != 3 || toks[0] != schema.PartitionKey || toks[1] != "=" {
+		return keyCondition{}, fmt.Errorf("ValidationException: partition key equality is required")
+	}
+	pk, ok := values[toks[2]]
+	if !ok {
+		return keyCondition{}, fmt.Errorf("ValidationException: missing expression value %s", toks[2])
+	}
+	out := keyCondition{pkValue: pk}
+	if len(parts) == 1 {
+		return out, nil
+	}
+	skPart := strings.TrimSpace(parts[1])
+	if strings.HasPrefix(skPart, "begins_with(") && strings.HasSuffix(skPart, ")") {
+		inner := strings.TrimSuffix(strings.TrimPrefix(skPart, "begins_with("), ")")
+		args := strings.Split(inner, ",")
+		if len(args) != 2 {
+			return keyCondition{}, fmt.Errorf("ValidationException: invalid begins_with expression")
+		}
+		if strings.TrimSpace(args[0]) != schema.SortKey {
+			return keyCondition{}, fmt.Errorf("ValidationException: invalid sort key in begins_with")
+		}
+		v := strings.TrimSpace(args[1])
+		out.skOp = "begins_with"
+		out.skOne = values[v]
+		if out.skOne == nil {
+			return keyCondition{}, fmt.Errorf("ValidationException: missing expression value %s", v)
+		}
+		return out, nil
+	}
+	toks = strings.Fields(skPart)
+	if len(toks) == 5 && toks[1] == "BETWEEN" && toks[3] == "AND" {
+		if toks[0] != schema.SortKey {
+			return keyCondition{}, fmt.Errorf("ValidationException: invalid sort key in BETWEEN")
+		}
+		out.skOp = "BETWEEN"
+		out.skOne = values[toks[2]]
+		out.skTwo = values[toks[4]]
+		if out.skOne == nil || out.skTwo == nil {
+			return keyCondition{}, fmt.Errorf("ValidationException: missing expression value")
+		}
+		return out, nil
+	}
+	if len(toks) != 3 || toks[0] != schema.SortKey {
+		return keyCondition{}, fmt.Errorf("ValidationException: invalid sort key expression")
+	}
+	if toks[1] != "=" && toks[1] != "<" && toks[1] != "<=" && toks[1] != ">" && toks[1] != ">=" {
+		return keyCondition{}, fmt.Errorf("ValidationException: unsupported operator %s", toks[1])
+	}
+	out.skOp = toks[1]
+	out.skOne = values[toks[2]]
+	if out.skOne == nil {
+		return keyCondition{}, fmt.Errorf("ValidationException: missing expression value %s", toks[2])
+	}
+	return out, nil
+}
+
+func (k keyCondition) matchesSort(av types.AttributeValue) (bool, error) {
+	if k.skOp == "" {
+		return true, nil
+	}
+	cmp, err := compareAttributeValues(av, k.skOne)
+	if err != nil {
+		return false, err
+	}
+	switch k.skOp {
+	case "=":
+		return cmp == 0, nil
+	case "<":
+		return cmp < 0, nil
+	case "<=":
+		return cmp <= 0, nil
+	case ">":
+		return cmp > 0, nil
+	case ">=":
+		return cmp >= 0, nil
+	case "BETWEEN":
+		cmp2, err := compareAttributeValues(av, k.skTwo)
+		if err != nil {
+			return false, err
+		}
+		return cmp >= 0 && cmp2 <= 0, nil
+	case "begins_with":
+		a, okA := av.(*types.AttributeValueMemberS)
+		b, okB := k.skOne.(*types.AttributeValueMemberS)
+		if !okA || !okB {
+			return false, fmt.Errorf("ValidationException: begins_with supports String sort keys only")
+		}
+		return strings.HasPrefix(a.Value, b.Value), nil
+	default:
+		return false, fmt.Errorf("ValidationException: unsupported sort key operator")
+	}
+}
+
+func attributeEqual(a, b types.AttributeValue) bool {
+	cmp, err := compareAttributeValues(a, b)
+	return err == nil && cmp == 0
+}
+
+func compareAttributeValues(a, b types.AttributeValue) (int, error) {
+	switch av := a.(type) {
+	case *types.AttributeValueMemberS:
+		bv, ok := b.(*types.AttributeValueMemberS)
+		if !ok {
+			return 0, fmt.Errorf("ValidationException: incompatible key types")
+		}
+		return strings.Compare(av.Value, bv.Value), nil
+	case *types.AttributeValueMemberN:
+		bv, ok := b.(*types.AttributeValueMemberN)
+		if !ok {
+			return 0, fmt.Errorf("ValidationException: incompatible key types")
+		}
+		aNum, ok := new(big.Rat).SetString(av.Value)
+		if !ok {
+			return 0, fmt.Errorf("ValidationException: invalid numeric key %q", av.Value)
+		}
+		bNum, ok := new(big.Rat).SetString(bv.Value)
+		if !ok {
+			return 0, fmt.Errorf("ValidationException: invalid numeric key %q", bv.Value)
+		}
+		return aNum.Cmp(bNum), nil
+	case *types.AttributeValueMemberB:
+		bv, ok := b.(*types.AttributeValueMemberB)
+		if !ok {
+			return 0, fmt.Errorf("ValidationException: incompatible key types")
+		}
+		return bytes.Compare(av.Value, bv.Value), nil
+	default:
+		return 0, fmt.Errorf("ValidationException: key must be scalar")
+	}
+}
+
+func keyFromItem(item map[string]types.AttributeValue, schema TableSchema) map[string]types.AttributeValue {
+	out := map[string]types.AttributeValue{schema.PartitionKey: item[schema.PartitionKey]}
+	if schema.SortKey != "" {
+		out[schema.SortKey] = item[schema.SortKey]
 	}
 	return out
 }


### PR DESCRIPTION
### Motivation

- Phase 1 requires end-to-end `Query`/`Scan` support but the server dispatch and engine interface had no Query/Scan paths. 
- Additions are intended to enable Query/Scan round-trip compatibility tests with the AWS SDK v2 harness and to close the Phase 1 gap.

### Description

- Add `Query` and `Scan` handlers to the HTTP dispatch in `pkg/api/server.go` with parsing for `KeyConditionExpression`, expression attribute maps, `Limit`, `ExclusiveStartKey`, `ScanIndexForward`, and `Select` and shared collection response encoding (`Items`, `Count`, `ScannedCount`, `LastEvaluatedKey`).
- Extend the `storage.Engine` interface with `Query`/`Scan` contracts and implement both in `pkg/storage/engine.go` for the in-memory backend including pagination and `Select=COUNT` support.
- Implement key-condition parsing and evaluation for partition key equality and sort-key operators `=`, `<`, `<=`, `>`, `>=`, `BETWEEN`, and `begins_with`, plus scalar comparison helpers for S/N/B types and LastEvaluatedKey/ExclusiveStartKey handling.
- Add an integration test `TestQueryAndScanRoundTrip` that exercises descending ordering, paged queries with `LastEvaluatedKey`/`ExclusiveStartKey`, full table scan, and `Select=COUNT` using the AWS SDK v2 client against the local harness (`integration/phase0_phase1_test.go`).

### Testing

- Ran `gofmt` and the full test suite with `go test ./...`, which completed successfully and reported the integration package tests passing.
- New integration test `TestQueryAndScanRoundTrip` executed and passed as part of the test run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698bd183b334832f90405a3fcdb39d0c)