### PR TITLE
Add UpdateTable dispatch and lifecycle integration coverage

### DIFF
--- a/integration/phase0_phase1_test.go
+++ b/integration/phase0_phase1_test.go
@@ -67,6 +67,20 @@ func TestTableLifecycleAndCoreCRUD(t *testing.T) {
 		t.Fatalf("unexpected describe output: %#v", descOut.Table)
 	}
 
+	updateTableOut, err := client.UpdateTable(ctx, &dynamodb.UpdateTableInput{
+		TableName: aws.String("phase1_items"),
+		StreamSpecification: &types.StreamSpecification{
+			StreamEnabled:  aws.Bool(true),
+			StreamViewType: types.StreamViewTypeNewImage,
+		},
+	})
+	if err != nil {
+		t.Fatalf("update table failed: %v", err)
+	}
+	if updateTableOut.TableDescription == nil || aws.ToString(updateTableOut.TableDescription.TableName) != "phase1_items" {
+		t.Fatalf("unexpected update table output: %#v", updateTableOut.TableDescription)
+	}
+
 	_, err = client.PutItem(ctx, &dynamodb.PutItemInput{
 		TableName: aws.String("phase1_items"),
 		Item: map[string]types.AttributeValue{


### PR DESCRIPTION
### Motivation

- Close a lifecycle checklist gap where `UpdateTable` was referenced but not handled by the server dispatch, causing incomplete Phase 0/1 coverage.
- Provide a minimal, testable `UpdateTable` behavior so lifecycle integration tests can assert expected response shapes for table updates.

### Description

- Add `UpdateTable` routing to the API dispatcher and implement a minimal `updateTable` handler in `pkg/api/server.go` that validates the JSON input, requires `TableName`, returns `ResourceNotFoundException` for unknown tables, and emits a DynamoDB-style `TableDescription` for existing tables.
- Extend the integration test `TestTableLifecycleAndCoreCRUD` in `integration/phase0_phase1_test.go` to call `UpdateTable` (including a `StreamSpecification`) and assert the returned `TableDescription.TableName` is correct.

### Testing

- Ran the test suite with `go test ./...` and the integration tests passed successfully.
- No unit tests were added to other packages in this change and the added integration assertion confirmed the `UpdateTable` lifecycle coverage gap is exercised.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698bd3732e44832f94cd89e78b3a1006)