### PR TITLE
Implement TransactWriteItems with atomic apply + rollback semantics

### DIFF
--- a/README.md
+++ b/README.md
@@ -582,8 +582,8 @@ Pass criteria for each item:
 
 - [ ] `BatchWriteItem` put/delete mix across tables
 - [ ] `BatchGetItem` key batches across tables
-- [ ] `TransactWriteItems` atomic success path
-- [ ] `TransactWriteItems` rollback on condition failure
+- [x] `TransactWriteItems` atomic success path
+- [x] `TransactWriteItems` rollback on condition failure
 - [ ] `TransactGetItems` consistent multi-item read behavior
 
 #### Streams, PartiQL, and Advanced
@@ -597,7 +597,7 @@ Pass criteria for each item:
 ### 6.6 Current Phase 0/1 Progress Snapshot
 
 - Completed: Phase 0 compatibility harness (dql vs DynamoDB Local), operation dispatch/error surface, table lifecycle (`CreateTable`/`DescribeTable`/`ListTables`/`DeleteTable`/baseline `UpdateTable` stubs), memory-backed CRUD, query/scan pagination + count basics, and conditional/update expression support (`ConditionExpression`, `UpdateExpression` with `SET`/`REMOVE`/`ADD` number+set/`DELETE` set).
-- In progress: remaining Phase 1 compatibility gaps outside query/scan parity checklist (batch/transaction/streams/partiql/ttl).
+- In progress: remaining Phase 1 compatibility gaps outside query/scan parity checklist (batch, `TransactGetItems`, streams/partiql/ttl).
 
 ### 6.6.1 Deferred-but-Accepted Expression Gaps (Backlog)
 


### PR DESCRIPTION
### Motivation
- Add DynamoDB `TransactWriteItems` support so multi-operation transactions can succeed atomically or be fully rolled back on conditional failures.
- Provide a storage-layer primitive that can model `Put`/`Delete`/`Update`/`ConditionCheck` actions and run them safely in-memory for test and compatibility harness use.

### Description
- Add `TransactWriteItems(actions []TransactWriteAction) error` to the `storage.Engine` API and introduce the `TransactWriteAction` model containing `PutItem`, `DeleteKey`, `UpdateKey`, `ConditionKey`, `Update` and `ConditionCheck` fields in `pkg/storage/engine.go`.
- Implement `MemoryEngine.TransactWriteItems` as a copy-on-write commit over cloned table state so all actions are applied to working copies and then swapped into `m.tables` only if every action succeeds, returning `TransactionCanceledException` on condition failures.
- Wire the API routing for `TransactWriteItems` in `pkg/api/server.go` and implement `transactWriteItems` to parse the DynamoDB request shapes, validate that each `TransactItem` contains exactly one operation, resolve `ExpressionAttributeNames`/`Values`, and translate condition/update expressions into storage callbacks.
- Add an integration test `TestTransactWriteItemsSuccessAndRollback` in `integration/phase0_phase1_test.go` that verifies a successful multi-action transaction commits all changes and that a transaction with a failing `ConditionCheck` rolls back any prior in-transaction changes; update the README checklist to reflect the new coverage.

### Testing
- Ran `go test ./...` and the test suite completed successfully with the integration tests and `pkg/api` tests passing (`ok` reported for `integration` and `pkg/api`).
- The new integration test `TestTransactWriteItemsSuccessAndRollback` executed as part of the suite and passed, validating both the commit and rollback behavior for transactions.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698cb0abb66c832f99caaca81f3d22f0)